### PR TITLE
Add WordPress block dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+wp-content/plugins/*/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# WordPress Gutenberg Block Lab
+
+This repository provides a local environment for building and testing custom Gutenberg blocks.
+
+## Requirements
+- Docker and Docker Compose
+- Node.js 18 or later
+
+## Setup
+
+1. Start WordPress and MySQL using Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+   WordPress will be available at [http://localhost:8000](http://localhost:8000).
+
+2. Install block development dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Build the example block:
+   ```bash
+   npm run build
+   ```
+
+   For development with automatic rebuilds, run:
+   ```bash
+   npm run start
+   ```
+
+4. Activate the plugin inside WordPress using WP-CLI:
+   ```bash
+   npm run wp plugin activate my-custom-block
+   ```
+
+The `npm run wp` command allows you to run any WP‑CLI command. For example, to install WordPress with test data:
+```bash
+npm run wp core install --url=http://localhost:8000 --title=WP --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+```
+
+## Directory Structure
+- `docker-compose.yml` – Docker setup for WordPress, MySQL and WP‑CLI
+- `plugins/my-custom-block/` – Sample block plugin scaffolded with `@wordpress/create-block`
+
+After running the above commands you can immediately start modifying the files in `plugins/my-custom-block/src/` and see changes reflected in your local WordPress site.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-proot"]
+      retries: 3
+      timeout: 5s
+
+  wordpress:
+    depends_on:
+      db:
+        condition: service_healthy
+    image: wordpress:latest
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ./plugins:/var/www/html/wp-content/plugins
+
+  wpcli:
+    image: wordpress:cli
+    depends_on:
+      - wordpress
+    volumes:
+      - ./plugins:/var/www/html/wp-content/plugins
+    entrypoint: ["wp"]
+    command: ["--path=/var/www/html"]
+    tty: true
+
+volumes:
+  db_data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "wp-lab",
+  "private": true,
+  "scripts": {
+    "build": "npm --prefix plugins/my-custom-block run build",
+    "start": "npm --prefix plugins/my-custom-block run start",
+    "wp": "docker compose run --rm wpcli"
+  }
+}

--- a/plugins/my-custom-block/block.json
+++ b/plugins/my-custom-block/block.json
@@ -1,0 +1,16 @@
+{
+    "apiVersion": 2,
+    "name": "create-block/my-custom-block",
+    "version": "0.1.0",
+    "title": "My Custom Block",
+    "category": "widgets",
+    "icon": "smiley",
+    "description": "Example block",
+    "supports": {
+        "html": false
+    },
+    "textdomain": "my-custom-block",
+    "editorScript": "file:./build/index.js",
+    "editorStyle": "file:./build/index.css",
+    "style": "file:./build/style-index.css"
+}

--- a/plugins/my-custom-block/my-custom-block.php
+++ b/plugins/my-custom-block/my-custom-block.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name:       My Custom Block
+ * Description:       Example block scaffolded with create-block.
+ * Requires at least: 6.0
+ * Requires PHP:      7.0
+ * Version:           0.1.0
+ * Author:            Your Name
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       my-custom-block
+ */
+
+function create_block_my_custom_block_init() {
+    register_block_type( __DIR__ . '/build' );
+}
+add_action( 'init', 'create_block_my_custom_block_init' );

--- a/plugins/my-custom-block/package.json
+++ b/plugins/my-custom-block/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "my-custom-block",
+  "version": "0.1.0",
+  "description": "Example block",
+  "scripts": {
+    "build": "wp-scripts build",
+    "start": "wp-scripts start"
+  },
+  "devDependencies": {
+    "@wordpress/scripts": "^26.0.0"
+  }
+}

--- a/plugins/my-custom-block/src/edit.js
+++ b/plugins/my-custom-block/src/edit.js
@@ -1,0 +1,9 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import './editor.scss';
+
+export default function Edit() {
+    return (
+        <p {...useBlockProps() }>{ __('My Custom Block – hello from the editor!', 'my-custom-block') }</p>
+    );
+}

--- a/plugins/my-custom-block/src/editor.scss
+++ b/plugins/my-custom-block/src/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-create-block-my-custom-block {
+    background: #f0f0f0;
+}

--- a/plugins/my-custom-block/src/index.js
+++ b/plugins/my-custom-block/src/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import save from './save';
+import metadata from '../block.json';
+
+registerBlockType(metadata, {
+    edit: Edit,
+    save,
+});

--- a/plugins/my-custom-block/src/save.js
+++ b/plugins/my-custom-block/src/save.js
@@ -1,0 +1,8 @@
+import { useBlockProps } from '@wordpress/block-editor';
+import './style.scss';
+
+export default function save() {
+    return (
+        <p {...useBlockProps.save()}>My Custom Block – hello from the saved content!</p>
+    );
+}

--- a/plugins/my-custom-block/src/style.scss
+++ b/plugins/my-custom-block/src/style.scss
@@ -1,0 +1,3 @@
+.wp-block-create-block-my-custom-block {
+    border: 1px dashed #ccc;
+}


### PR DESCRIPTION
## Summary
- add docker-compose for WordPress, MySQL and wp-cli
- scaffold sample Gutenberg block plugin
- add npm scripts to build and run wp-cli
- document setup instructions

## Testing
- `npm test` *(fails: Missing script)*