### PR TITLE
Automate WordPress initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 wp-content/plugins/*/node_modules/
 .env
+package-lock.json
+plugins/*/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ wp-content/plugins/*/node_modules/
 .env
 package-lock.json
 plugins/*/package-lock.json
+package-lock.json
+plugins/*/package-lock.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This repository provides a local environment for building and testing custom Gut
    ```bash
    docker-compose up -d
    ```
-   WordPress will be available at [http://localhost:8000](http://localhost:8000).
+   Once the containers start, WordPress will automatically be installed and the
+   example plugin activated. Access the site at
+   [http://localhost:8000](http://localhost:8000).
 
 2. Install block development dependencies:
    ```bash
@@ -29,10 +31,10 @@ This repository provides a local environment for building and testing custom Gut
    npm run start
    ```
 
-4. Activate the plugin inside WordPress using WP-CLI:
-   ```bash
-   npm run wp plugin activate my-custom-block
-   ```
+If you ever need to reinstall WordPress or reactivate the example plugin, run:
+```bash
+npm run setup
+```
 
 The `npm run wp` command allows you to run any WP‑CLI command. For example, to install WordPress with test data:
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
     volumes:
+      - wp_data:/var/www/html
       - ./plugins:/var/www/html/wp-content/plugins
 
   wpcli:
@@ -35,10 +36,24 @@ services:
     depends_on:
       - wordpress
     volumes:
+      - wp_data:/var/www/html
       - ./plugins:/var/www/html/wp-content/plugins
+      - ./init.sh:/init.sh
     entrypoint: ["wp"]
     command: ["--path=/var/www/html"]
     tty: true
 
+  setup:
+    image: wordpress:cli
+    depends_on:
+      - wordpress
+    volumes:
+      - wp_data:/var/www/html
+      - ./plugins:/var/www/html/wp-content/plugins
+      - ./init.sh:/init.sh
+    entrypoint: ["sh", "/init.sh"]
+    restart: "no"
+
 volumes:
   db_data:
+  wp_data:

--- a/init.sh
+++ b/init.sh
@@ -13,7 +13,7 @@ tries=0
 while ! wp --path="$WP_PATH" core version --allow-root >/dev/null 2>&1; do
   if [ "$tries" -ge 10 ]; then
     echo "WordPress files not found." >&2
-    break
+    exit 1
   fi
   echo "Waiting for WordPress files..."
   sleep 3

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+WP_PATH=/var/www/html
+URL=${WORDPRESS_URL:-http://localhost:8000}
+TITLE=${WORDPRESS_TITLE:-WordPress}
+ADMIN_USER=${WORDPRESS_ADMIN_USER:-admin}
+ADMIN_PASSWORD=${WORDPRESS_ADMIN_PASSWORD:-admin}
+ADMIN_EMAIL=${WORDPRESS_ADMIN_EMAIL:-admin@example.com}
+
+# Wait for WordPress files to be available
+tries=0
+while ! wp --path="$WP_PATH" core version --allow-root >/dev/null 2>&1; do
+  if [ "$tries" -ge 10 ]; then
+    echo "WordPress files not found." >&2
+    break
+  fi
+  echo "Waiting for WordPress files..."
+  sleep 3
+  tries=$((tries + 1))
+done
+
+if ! wp --path="$WP_PATH" core is-installed --allow-root >/dev/null 2>&1; then
+  echo "Installing WordPress..."
+  wp --path="$WP_PATH" core install \
+    --url="$URL" \
+    --title="$TITLE" \
+    --admin_user="$ADMIN_USER" \
+    --admin_password="$ADMIN_PASSWORD" \
+    --admin_email="$ADMIN_EMAIL" \
+    --skip-email \
+    --allow-root
+fi
+
+wp --path="$WP_PATH" plugin activate my-custom-block --allow-root || true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "npm --prefix plugins/my-custom-block run build",
     "start": "npm --prefix plugins/my-custom-block run start",
     "wp": "docker compose run --rm wpcli",
+    "setup": "docker compose run --rm wpcli sh /init.sh",
     "test": "jest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "npm --prefix plugins/my-custom-block run build",
     "start": "npm --prefix plugins/my-custom-block run start",
     "wp": "docker compose run --rm wpcli",
-    "setup": "docker compose run --rm wpcli sh /init.sh",
+    "setup": "docker compose run --rm setup",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- auto install WordPress and activate example plugin when containers start
- add `npm run setup` for re-running the initialization
- share WordPress files among containers
- ignore package lock files

## Testing
- `npm test`